### PR TITLE
Upgrade dependencies to support PHP 8.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 vendor
 composer.lock
+.phpunit.cache
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,16 @@
 {
     "name": "rareloop/psr7-server-request-extension",
     "require": {
-        "psr/http-message": "^2"
+        "psr/http-message": "^2",
+        "php": "^8.4"
     },
     "require-dev": {
         "laminas/laminas-diactoros": "^3.6",
         "phpunit/phpunit": "^12",
         "mockery/mockery": "^1.6",
         "brain/monkey": "^2.6.2",
-        "squizlabs/php_codesniffer": "^3.7.2"
+        "squizlabs/php_codesniffer": "^3.7.2",
+        "rector/rector": "^2.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "rareloop/psr7-server-request-extension",
     "require": {
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^2"
     },
     "require-dev": {
         "laminas/laminas-diactoros": "^3.6",

--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,11 @@
         "psr/http-message": "^1.0"
     },
     "require-dev": {
-        "laminas/laminas-diactoros": "^2.4",
-        "phpunit/phpunit": "^6.0",
-        "mockery/mockery": "^1.0.0",
-        "brain/monkey": "^2.0.2",
-        "satooshi/php-coveralls": "^1.0",
-        "squizlabs/php_codesniffer": "^3.5",
-        "codedungeon/phpunit-result-printer": "^0.4.4"
+        "laminas/laminas-diactoros": "^3.6",
+        "phpunit/phpunit": "^12",
+        "mockery/mockery": "^1.6",
+        "brain/monkey": "^2.6.2",
+        "squizlabs/php_codesniffer": "^3.7.2"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.2/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache" backupGlobals="false" backupStaticProperties="false">
-
-    <testsuites>
-        <testsuite name="Rareloop Lumberjack Validation">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <source>
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </source>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache" backupGlobals="false" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Rareloop Lumberjack Validation">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,23 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         printerClass="Codedungeon\PHPUnitPrettyResultPrinter\Printer">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.2/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache" backupGlobals="false" backupStaticProperties="false">
+
     <testsuites>
         <testsuite name="Rareloop Lumberjack Validation">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withPhpSets(php84: true)
+    ->withTypeCoverageLevel(0)
+    ->withDeadCodeLevel(0)
+    ->withCodeQualityLevel(0);

--- a/src/InteractsWithUri.php
+++ b/src/InteractsWithUri.php
@@ -33,6 +33,6 @@ trait InteractsWithUri
 
     public function isMethod($method): bool
     {
-        return strtolower($method) === strtolower($this->getMethod());
+        return strtolower((string) $method) === strtolower($this->getMethod());
     }
 }

--- a/tests/TestDiactorosServerRequest.php
+++ b/tests/TestDiactorosServerRequest.php
@@ -4,7 +4,7 @@ namespace Rareloop\Psr7ServerRequestExtension\Test;
 
 use Rareloop\Psr7ServerRequestExtension\InteractsWithInput;
 use Rareloop\Psr7ServerRequestExtension\InteractsWithUri;
-use Zend\Diactoros\ServerRequest;
+use Laminas\Diactoros\ServerRequest;
 
 class TestDiactorosServerRequest extends ServerRequest
 {

--- a/tests/Unit/Psr7ServerRequestExtensionTest.php
+++ b/tests/Unit/Psr7ServerRequestExtensionTest.php
@@ -2,12 +2,13 @@
 
 namespace Rareloop\Psr7ServerRequestExtension\Test;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Rareloop\Psr7ServerRequestExtension\Test\TestDiactorosServerRequest as ServerRequest;
 
 class Psr7ServerRequestExtensionTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function can_get_path()
     {
         $request = new ServerRequest([], [], '/test/123', 'GET');
@@ -15,7 +16,7 @@ class Psr7ServerRequestExtensionTest extends TestCase
         $this->assertSame('/test/123', $request->path());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_url_without_query_string()
     {
         $request = new ServerRequest([], [], 'https://test.com/test/123?foo=bar', 'GET');
@@ -23,7 +24,7 @@ class Psr7ServerRequestExtensionTest extends TestCase
         $this->assertSame('https://test.com/test/123', $request->url());
     }
 
-    /** @test */
+    #[Test]
     public function can_get_url_with_query_string()
     {
         $request = new ServerRequest([], [], 'https://test.com/test/123?foo=bar', 'GET');
@@ -31,7 +32,7 @@ class Psr7ServerRequestExtensionTest extends TestCase
         $this->assertSame('https://test.com/test/123?foo=bar', $request->fullUrl());
     }
 
-    /** @test */
+    #[Test]
     public function no_trailing_question_mark_is_added_when_no_query_params_are_present()
     {
         $request = new ServerRequest([], [], 'https://test.com/test/123', 'GET');
@@ -39,7 +40,7 @@ class Psr7ServerRequestExtensionTest extends TestCase
         $this->assertSame('https://test.com/test/123', $request->fullUrl());
     }
 
-    /** @test */
+    #[Test]
     public function can_check_method()
     {
         $request = new ServerRequest([], [], '/test/123', 'GET');
@@ -50,7 +51,7 @@ class Psr7ServerRequestExtensionTest extends TestCase
         $this->assertFalse($request->isMethod('POST'));
     }
 
-    /** @test */
+    #[Test]
     public function can_get_all_input()
     {
         $request = new ServerRequest([], [], '/test/123', 'GET', 'php://input', [], [], ['foo' => 'bar'], ['baz' => 'qux']);
@@ -61,7 +62,7 @@ class Psr7ServerRequestExtensionTest extends TestCase
         $this->assertSame('qux', $input['baz']);
     }
 
-    /** @test */
+    #[Test]
     public function can_get_specific_input_with_key()
     {
         $request = new ServerRequest([], [], '/test/123', 'GET', 'php://input', [], [], ['foo' => 'bar'], ['baz' => 'qux']);
@@ -70,7 +71,7 @@ class Psr7ServerRequestExtensionTest extends TestCase
         $this->assertSame('qux', $request->input('baz'));
     }
 
-    /** @test */
+    #[Test]
     public function can_get_default_when_key_is_not_found_in_input()
     {
         $request = new ServerRequest([], [], '/test/123', 'GET');
@@ -78,7 +79,7 @@ class Psr7ServerRequestExtensionTest extends TestCase
         $this->assertSame('bar', $request->input('foo', 'bar'));
     }
 
-    /** @test */
+    #[Test]
     public function can_check_if_input_has_a_specific_key()
     {
         $request = new ServerRequest([], [], '/test/123', 'GET', 'php://input', [], [], ['foo' => 'bar']);
@@ -87,7 +88,7 @@ class Psr7ServerRequestExtensionTest extends TestCase
         $this->assertFalse($request->has('baz'));
     }
 
-    /** @test */
+    #[Test]
     public function can_check_if_input_has_collection_of_keys()
     {
         $request = new ServerRequest([], [], '/test/123', 'GET', 'php://input', [], [], ['foo' => 'bar'], ['baz' => 'qux']);
@@ -95,7 +96,7 @@ class Psr7ServerRequestExtensionTest extends TestCase
         $this->assertTrue($request->has(['foo', 'baz']));
     }
 
-    /** @test */
+    #[Test]
     public function can_get_all_query()
     {
         $request = new ServerRequest([], [], '/test/123', 'GET', 'php://input', [], [], ['foo' => 'bar'], ['baz' => 'qux']);
@@ -106,7 +107,7 @@ class Psr7ServerRequestExtensionTest extends TestCase
         $this->assertFalse(isset($input['baz']));
     }
 
-    /** @test */
+    #[Test]
     public function can_get_specific_query_with_key()
     {
         $request = new ServerRequest([], [], '/test/123', 'GET', 'php://input', [], [], ['foo' => 'bar'], ['baz' => 'qux']);
@@ -114,7 +115,7 @@ class Psr7ServerRequestExtensionTest extends TestCase
         $this->assertSame('bar', $request->query('foo'));
     }
 
-    /** @test */
+    #[Test]
     public function can_get_default_when_key_is_not_found_in_query()
     {
         $request = new ServerRequest([], [], '/test/123', 'GET');
@@ -122,7 +123,7 @@ class Psr7ServerRequestExtensionTest extends TestCase
         $this->assertSame('bar', $request->query('foo', 'bar'));
     }
 
-    /** @test */
+    #[Test]
     public function can_get_all_post()
     {
         $request = new ServerRequest([], [], '/test/123', 'GET', 'php://input', [], [], ['foo' => 'bar'], ['baz' => 'qux']);
@@ -133,7 +134,7 @@ class Psr7ServerRequestExtensionTest extends TestCase
         $this->assertFalse(isset($input['foo']));
     }
 
-    /** @test */
+    #[Test]
     public function can_get_specific_post_with_key()
     {
         $request = new ServerRequest([], [], '/test/123', 'GET', 'php://input', [], [], ['foo' => 'bar'], ['baz' => 'qux']);
@@ -141,7 +142,7 @@ class Psr7ServerRequestExtensionTest extends TestCase
         $this->assertSame('qux', $request->post('baz'));
     }
 
-    /** @test */
+    #[Test]
     public function can_get_default_when_key_is_not_found_in_post()
     {
         $request = new ServerRequest([], [], '/test/123', 'GET');


### PR DESCRIPTION
Tweaked from #1 

# Dependency Upgrades

This PR upgrades all depdencencies

* `laminas/laminas-diactoros` - 2.x → 3.x - No breaking changes (see the [upgrade guide](https://docs.laminas.dev/laminas-diactoros/v3/migration/)).
* `psr/http-message` - 1.x → 2.x - No breaking changes
* `phpunit/phpunit` - 6.x -> 12.x - No breaking changes to consumers

## Breaking Changes

* **Now requires PHP 8.1 ⚠️**

## Note on testing

The test suite has been migrated to PHPUnit 12 (from 6). This meant replacing `/** @test */` with `#[Test]`. `codedungeon/phpunit-result-printer` has been removed, PHPUnit formats the output well enough now.